### PR TITLE
Fix docs.strongloop.com URLs

### DIFF
--- a/LoopbackGuideApplication/res/values/strings.xml
+++ b/LoopbackGuideApplication/res/values/strings.xml
@@ -9,7 +9,8 @@
         <p>For more technical insights, check out LoopBack on GitHub:</p>
         <p><a href="https://github.com/strongloop/loopback">github.com/strongloop/loopback</a></p>
         <p>and our extended documentation:</p>
-        <p><a href="http://docs.strongloop.com/loopback">docs.strongloop.com/loopback</a></p>
+        <p><a href="http://docs.strongloop.com/display/DOC/LoopBack">
+          docs.strongloop.com/display/DOC/loopback</a></p>
         <p>To keep coding, poke around the Android project. For instance,
         have a look at the way the app shares a single instance of <tt>RestAdapter</tt>
         through <tt>GuideApplication</tt>, or read through more of the comments

--- a/LoopbackGuideSkeleton/res/values/strings.xml
+++ b/LoopbackGuideSkeleton/res/values/strings.xml
@@ -9,7 +9,8 @@
         <p>For more technical insights, check out LoopBack on GitHub:</p>
         <p><a href="https://github.com/strongloop/loopback">github.com/strongloop/loopback</a></p>
         <p>and our extended documentation:</p>
-        <p><a href="http://docs.strongloop.com/loopback">docs.strongloop.com/loopback</a></p>
+        <p><a href="http://docs.strongloop.com/display/DOC/LoopBack">
+          docs.strongloop.com/display/DOC/LoopBack</a></p>
         <p>To keep coding, poke around the Android project. For instance,
         have a look at the way the app shares a single instance of <tt>RestAdapter</tt>
         through <tt>GuideApplication</tt>, or read through more of the comments


### PR DESCRIPTION
Use the new URLs used by the Confluence version of the docs.

//cc @crandmck 
